### PR TITLE
Replace usage of deprecated library

### DIFF
--- a/CVE_2017_7921_EXP.py
+++ b/CVE_2017_7921_EXP.py
@@ -2,7 +2,7 @@
 
 from io import BytesIO
 from itertools import cycle
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 import requests
 from operator import itemgetter
 from pathlib import Path
@@ -24,7 +24,7 @@ def decrypt(ciphertext, hex_key='279977f62f6cfd2d91cd75b889ce0c9a'):
     key = bytes.fromhex(hex_key)
     ciphertext = add_to_16(ciphertext)
     iv = ciphertext[:AES.block_size]
-    cipher = AES.new(key, AES.MODE_ECB, iv)
+    cipher = AES.new(key, AES.MODE_ECB)
     plaintext = cipher.decrypt(ciphertext[AES.block_size:])
     return plaintext.rstrip(b"\0")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.23.0
 fire==0.2.1
-pycrypto==2.6.1
+pycryptodome


### PR DESCRIPTION
refactor: Replace usage of deprecated library

In this commit, I have replaced the usage of the deprecated pycrypto library with the pycryptodome library. The pycryptodome library serves as a compatible replacement and addresses the deprecation concerns. This update ensures that the codebase remains up-to-date and uses a maintained cryptographic library.
